### PR TITLE
Update to acknowledgements

### DIFF
--- a/chapters/git-advanced.Rmd
+++ b/chapters/git-advanced.Rmd
@@ -11,11 +11,6 @@ they allow us to go through the write-review-revise cycle
 familiar to anyone who has ever written a journal paper
 in hours rather than weeks.
 
-> This lesson is derived in part from one created at
-> [the University of Wisconsin-Madison][uwm-git-lesson].
-> We are grateful to its authors for using an open license
-> so that we could reuse their work.
-
 Your `zipf` project directory should now include:
 
 ```text

--- a/index.Rmd
+++ b/index.Rmd
@@ -322,7 +322,7 @@ zipf/
 This book owes its existence to
 everyone we met through [the Carpentries][carpentries].
 We are also grateful to [Insight Data Science][insight] for sponsoring the early stages of this work,
-to the authors of [@Nobl2009; @Hadd2010; @Wils2014; @Scop2015; @Tasc2017; @Wils2017; @Brow2018; @Deve2018; @Shol2019; @Wils2019],
+to the authors of @Nobl2009; @Hadd2010; @Wils2014; @Scop2015; @Tasc2017; @Wils2017; @Brow2018; @Deve2018; @Shol2019; @Wils2019,
 and to everyone who has contributed, including Madeleine Bonsma-Fisher,
 Jonathan Dursi,
 Christina Koch,
@@ -333,6 +333,12 @@ and Elizabeth Wickes.
 -   Many of the explanations and exercises in Chapters \@ref(bash-basics) and \@ref(bash-advanced)
     have been adapted from Software Carpentry's lesson
     [The Unix Shell](http://swcarpentry.github.io/shell-novice/).
+
+-   Many of explanations and exercises in Chapters \@ref(git-cmdline) and \@ref(git-advanced)
+    have been adapted from Software Carpentry's lesson
+    [Version Control with Git](http://swcarpentry.github.io/git-novice/) and an
+    [adaptation/extension of that lesson][uwm-git-lesson] maintained by
+    the University of Wisconsin-Madison Data Science Hub.
 
 -   Chapter \@ref(automate) is based on the [Software Carpentry lesson on Make][swc-make]
     maintained by [Gerard Capes][capes-gerard]


### PR DESCRIPTION
There was a stray acknowledgement at the beginning of the git advanced chapter, so I've moved it to the acknowledgements section in the introduction chapter.