### PR TITLE
Fix solution headings so TOC looks better. 

### DIFF
--- a/chapters/solutions.Rmd
+++ b/chapters/solutions.Rmd
@@ -2,7 +2,7 @@
 
 FIXME: Update the ordering of this section when we are finished rearranging.
 
-## Chapter \@ref(bash-basics)
+## Chapter: [The Basics of the Unix Shell]
 
 ### Exercise \@ref(bash-basics-ex-more-ls) {-}
 
@@ -332,7 +332,7 @@ have a record of the last command run in the event of a crash.
 -   followed by zero or more other characters (the `*`),
 -   followed by `.txt` or `.pdf`.
 
-## Chapter \@ref(bash-advanced)
+## Chapter: [Going Further with the Unix Shell]
 
 ### Exercise \@ref(bash-advanced-ex-cleaning-up) {-}
 
@@ -461,7 +461,7 @@ Assuming that Ahmed's home is our working directory we type:
 $ find ./ -type f -mtime -1 -user ahmed
 ```
 
-## Chapter \@ref(scripting)
+## Chapter: [Command Line Programs in Python]
 
 ### Exercise \@ref(scripting-ex-command-line) {-}
 
@@ -499,7 +499,7 @@ if __name__ == '__main__':
     main(args)
 ```
 
-## Chapter \@ref(git-cmdline)
+## Chapter: [Git at the Command Line]
 
 ### Exercise \@ref(git-cmdline-ex-places) {-}
 
@@ -711,7 +711,7 @@ to modify the line, when that change was made, and what the file name was
 or is called.
 2. FIXME: I don't see any `^` when I use it on a random file in the book repo.
 
-## Chapter \@ref(git-advanced)
+## Chapter: [Advanced Git]
 
 ### Exercise \@ref(git-advanced-ex-explain-options) {-}
 
@@ -737,7 +737,7 @@ FIXME
 
 FIXME
 
-## Chapter \@ref(teams)
+## Chapter: [Working in Teams]
 
 ### Exercise \@ref(teams-ex-scavenger-hunt) {-}
 
@@ -840,7 +840,7 @@ of duties, roles, and tasks the contributor provided for the project.
 
 FIXME
 
-## Chapter \@ref(automate)
+## Chapter: [Automating Analyses]
 
 ### Exercise \@ref(automate-ex-create-summary-results) {-}
 
@@ -876,7 +876,7 @@ FIXME
 
 FIXME
 
-## Chapter \@ref(config)
+## Chapter: [Program Configuration]
 
 ### Exercise \@ref(config-ex-build-plotparams) {-}
 
@@ -902,7 +902,7 @@ FIXME
 
 FIXME
 
-## Chapter \@ref(errors)
+## Chapter: [Error Handling]
 
 ### Exercise \@ref(errors-ex-set-level) {-}
 
@@ -1006,7 +1006,7 @@ FIXME
 
 FIXME
 
-## Chapter \@ref(testing)
+## Chapter: [Testing]
 
 ### Exercise \@ref(testing-ex-explain-assertions) {-}
 
@@ -1031,7 +1031,7 @@ FIXME
 
 FIXME
 
-## Chapter \@ref(provenance)
+## Chapter: [Provenance]
 
 ### Exercise \@ref(provenance-ex-get-orcid) {-}
 
@@ -1103,7 +1103,7 @@ points to ZIP archive for a specific release of your repository on GitHub, e.g. 
 
 FIXME
 
-## Chapter \@ref(packaging)
+## Chapter: [Python Packaging]
 
 ### Exercise \@ref(packaging-ex-fixing-warnings) {-}
 

--- a/chapters/solutions.Rmd
+++ b/chapters/solutions.Rmd
@@ -2,7 +2,7 @@
 
 FIXME: Update the ordering of this section when we are finished rearranging.
 
-## Chapter: [The Basics of the Unix Shell]
+## Chapter \@ref(bash-basics) {.unnumbered .unlisted}
 
 ### Exercise \@ref(bash-basics-ex-more-ls) {-}
 
@@ -332,7 +332,7 @@ have a record of the last command run in the event of a crash.
 -   followed by zero or more other characters (the `*`),
 -   followed by `.txt` or `.pdf`.
 
-## Chapter: [Going Further with the Unix Shell]
+## Chapter \@ref(bash-advanced) {.unnumbered .unlisted}
 
 ### Exercise \@ref(bash-advanced-ex-cleaning-up) {-}
 
@@ -461,7 +461,7 @@ Assuming that Ahmed's home is our working directory we type:
 $ find ./ -type f -mtime -1 -user ahmed
 ```
 
-## Chapter: [Command Line Programs in Python]
+## Chapter \@ref(scripting) {.unnumbered .unlisted}
 
 ### Exercise \@ref(scripting-ex-command-line) {-}
 
@@ -499,7 +499,7 @@ if __name__ == '__main__':
     main(args)
 ```
 
-## Chapter: [Git at the Command Line]
+## Chapter \@ref(git-cmdline) {.unnumbered .unlisted}
 
 ### Exercise \@ref(git-cmdline-ex-places) {-}
 
@@ -711,7 +711,7 @@ to modify the line, when that change was made, and what the file name was
 or is called.
 2. FIXME: I don't see any `^` when I use it on a random file in the book repo.
 
-## Chapter: [Advanced Git]
+## Chapter \@ref(git-advanced) {.unnumbered .unlisted}
 
 ### Exercise \@ref(git-advanced-ex-explain-options) {-}
 
@@ -737,7 +737,7 @@ FIXME
 
 FIXME
 
-## Chapter: [Working in Teams]
+## Chapter \@ref(teams) {.unnumbered .unlisted}
 
 ### Exercise \@ref(teams-ex-scavenger-hunt) {-}
 
@@ -840,7 +840,7 @@ of duties, roles, and tasks the contributor provided for the project.
 
 FIXME
 
-## Chapter: [Automating Analyses]
+## Chapter \@ref(automate) {.unnumbered .unlisted}
 
 ### Exercise \@ref(automate-ex-create-summary-results) {-}
 
@@ -876,7 +876,7 @@ FIXME
 
 FIXME
 
-## Chapter: [Program Configuration]
+## Chapter \@ref(config) {.unnumbered .unlisted}
 
 ### Exercise \@ref(config-ex-build-plotparams) {-}
 
@@ -902,7 +902,7 @@ FIXME
 
 FIXME
 
-## Chapter: [Error Handling]
+## Chapter \@ref(errors) {.unnumbered .unlisted}
 
 ### Exercise \@ref(errors-ex-set-level) {-}
 
@@ -1006,7 +1006,7 @@ FIXME
 
 FIXME
 
-## Chapter: [Testing]
+## Chapter \@ref(testing) {.unnumbered .unlisted}
 
 ### Exercise \@ref(testing-ex-explain-assertions) {-}
 
@@ -1031,7 +1031,7 @@ FIXME
 
 FIXME
 
-## Chapter: [Provenance]
+## Chapter \@ref(provenance) {.unnumbered .unlisted}
 
 ### Exercise \@ref(provenance-ex-get-orcid) {-}
 
@@ -1103,7 +1103,7 @@ points to ZIP archive for a specific release of your repository on GitHub, e.g. 
 
 FIXME
 
-## Chapter: [Python Packaging]
+## Chapter \@ref(packaging) {.unnumbered .unlisted}
 
 ### Exercise \@ref(packaging-ex-fixing-warnings) {-}
 


### PR DESCRIPTION
Resolves #474

@gvwilson is this fine? I couldn't do it with the `\@ref()` because it ends up being a Pandoc templating thing which I don't know enough about to get into. I think this actually looks better than if it was numbers :) 

![screenshot](https://user-images.githubusercontent.com/6662983/92991050-1f68c400-f4e1-11ea-9310-3ff461bf91c6.png)
