### PR TITLE
Removing contributor guide from book

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -28,7 +28,6 @@ rmd_files:
   - appendix.Rmd
   - LICENSE.md
   - CONDUCT.md
-  - CONTRIBUTING.md
   - glossary/glossary.md
   - chapters/install.Rmd
   - chapters/objectives.Rmd


### PR DESCRIPTION
Note: this will _also_ remove the contributor's guide from the web version, which we may not want, but trying to conditionally include a section in the HTML without messing up the appendix numbering (or lettering) in the PDF is beyond me.