### PR TITLE
Defining some Unicode box-drawing characters for tree output.

### DIFF
--- a/includes/preamble.tex
+++ b/includes/preamble.tex
@@ -55,4 +55,14 @@
 % Handle glossary links specially.
 \newcommand{\gref}[2]{\hyperlink{#2}{\textbf{#1}}}
 
+% Allow box-drawing characters
+% See https://tex.stackexchange.com/questions/281368/print-box-drawing-characters-with-pdflatex
+% and pg 185 of http://tug.ctan.org/info/symbols/comprehensive/symbols-a4.pdf
+\usepackage{pmboxdraw}
+\usepackage{newunicodechar}
+\newunicodechar{│}{\textSFxi}
+\newunicodechar{└}{\textSFii}
+\newunicodechar{├}{\textSFviii}
+\newunicodechar{─}{\textSFx}
+
 \frontmatter


### PR DESCRIPTION
Closes #543.
(Almost - some of the vertical bars don't render cleanly even though they seem to be the same character.)