### PR TITLE
Address wheels comment from Joel

### DIFF
--- a/chapters/packaging.Rmd
+++ b/chapters/packaging.Rmd
@@ -899,7 +899,7 @@ we can go through the same process to put it on the main [PyPI][pypi] repository
 >
 > When we installed our package from TestPyPI,
 > the output said that it collected our source distribution 
-> and then used it to "build a wheel" for `pyzipf`.
+> and then used it to build a \gref{wheel}{wheel} for `pyzipf`.
 > This build takes time (especially for large, complex packages),
 > so it can be a good idea for package authors to create and upload wheel files (`.whl`)
 > to PyPI along with the source distribution.

--- a/glossary/glossary.md
+++ b/glossary/glossary.md
@@ -675,6 +675,9 @@
 **virtual machine**<a id="virtual_machine"></a>
 :   A program that pretends to be a computer. This may seem a bit redundant, but VMs are quick to create and start up, and changes made inside the virtual machine are contained within that VM so we can install new \gref{packages}{package} or run a completely different operating system without affecting the underlying computer.
 
+**wheel**<a id="wheel"></a>
+:   A pre-built binary Python installation format that is smaller and faster to install than the \gref{source distribution}{source_distribution} but not as versatile.
+
 **whitespace**<a id="whitespace"></a>
 :   The space, newline, carriage return, and horizontal and vertical tab characters that take up space but do not create a visible mark. The name comes from their appearance on a printed page in the era of typewriters.
 


### PR DESCRIPTION
I didn't get a chance to address https://github.com/merely-useful/py-rse/pull/599#discussion_r557064922 from @joelostblom before #599 was merged. This PR basically takes Joel's suggested definition of a wheel and puts it in the glossary, since it felt a bit weird to talk about it being a "pre-built" thing when in the Python wheels call-out box we talk about the fact that pip built a wheel from the source distribution (i.e. in that instance it wasn't pre-built). Hope that makes sense. 