### PR TITLE
Add date and other info to Lin2020

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -462,7 +462,12 @@
   title = {{Ten Quick Tips for Making Things Findable}},
   journal = {{PLOS} Computational Biology},
   publisher = {Public Library of Science},
-  year = {in press},
+  year = {2020},
+  month = {12},
+  volume = {16},
+  url = {https://doi.org/10.1371/journal.pcbi.1008469},
+  pages = {1-10},
+  doi = {10.1371/journal.pcbi.1008469},
   note = {How to organize and label information to make it easier to search and discover.}
 }
 


### PR DESCRIPTION
The paper is no longer in press. This should update the citations from (Lin, Ali, and Wilson, n.d.) -> (Lin, Ali, and Wilson, 2020).