### PR TITLE
Fix typo in error message for directory copy

### DIFF
--- a/chapters/bash-basics.Rmd
+++ b/chapters/bash-basics.Rmd
@@ -831,7 +831,7 @@ $ cp docs backup
 ```
 
 ```text
-cp: analysis is a directory (not copied).
+cp: docs is a directory (not copied).
 ```
 
 If we really want to copy everything,


### PR DESCRIPTION
Tested with
```
% mkdir 1
% cp 1 2
cp: 1 is a directory (not copied).
```