### PR TITLE
Fix wrong md formatting in git exercise

### DIFF
--- a/chapters/git-cmdline.Rmd
+++ b/chapters/git-cmdline.Rmd
@@ -1509,7 +1509,8 @@ $ cat motivation.txt
 
 2. `Documenting major milestones.`
 
-3. ```text
+3. 
+```text
 Sharing information about myself.
 Documenting major milestones.
 ```


### PR DESCRIPTION
Code blocks are apparently not allowed within a numbered list. Needs a new line to be formatted correctly.

Currently, it looks like [this](https://merely-useful.tech/py-rse/git-cmdline.html#git-cmdline-ex-history)

Btw, great book :+1: Will use it in our course next semester.