### PR TITLE
Avoid implying that redirection is identical to a file parameter

### DIFF
--- a/chapters/bash-tools.Rmd
+++ b/chapters/bash-tools.Rmd
@@ -337,7 +337,7 @@ it just knows that it has to read, sort, and print.
 Just as we can redirect standard output with `>`,
 we can connect standard input to a file using `<`.\index{redirection (in Unix shell)}
 In the case of a single file,
-this has the same effect as providing the file's name to the command:
+this has the same effect as providing the file's name to the `wc` command:
 
 ```bash
 $ wc < moby_dick.txt


### PR DESCRIPTION
Not the only way to adjust this wording, but the redirection operator is not always identical to including a command-line parameter for a filename. Works for `wc`, `sort`, and similar filtering commands, but not everything such as `ls`, `cp`, etc.