### PR TITLE
Adding basic web site statistics using plausible.io.

### DIFF
--- a/includes/header.html
+++ b/includes/header.html
@@ -1,1 +1,2 @@
 <link rel="shortcut icon" href="favicon.ico" />
+<script defer data-domain="merely-useful.tech" src="https://plausible.io/js/plausible.js"></script>


### PR DESCRIPTION
https://plausible.io/ offers an ethical approach to collecting web traffic statistics. This addition will let us count the number of people visiting https://merely-useful.tech/ (we can then drill down to the py-rse book or others). I'm assuming that once this is merged, all of the HTML pages will be updated...